### PR TITLE
Add ReadOnly macro and interface

### DIFF
--- a/porcelain/ReadOnly.hx
+++ b/porcelain/ReadOnly.hx
@@ -1,0 +1,9 @@
+package porcelain;
+
+/** ReadOnly ensures all Observer fields are read only and cannot be written
+ * to unless using the @:access metadata.
+ */
+#if !macro
+@:autoBuild(porcelain.macros.ReadOnlyMacro.apply())
+#end
+interface ReadOnly {}

--- a/porcelain/macros/ReadOnlyMacro.hx
+++ b/porcelain/macros/ReadOnlyMacro.hx
@@ -1,0 +1,35 @@
+package porcelain.macros;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+using Lambda;
+using StringTools;
+
+/**
+ * Makes all fields with the @observe metadata into readonly properties.
+ * 
+ */
+class ReadOnlyMacro {
+  macro public static function apply(): Array<Field> {
+    var fields = Context.getBuildFields();
+
+    for (field in fields) {
+      var name = field.name;
+
+      if (field.meta.length > 0) {
+        for (meta in field.meta) {
+          if (meta.name == 'observe') {
+            var params = field.kind.getParameters();
+            var complexType = params[0];
+            var expr = params[1];
+            var newProp = FieldType.FProp('default', 'null', complexType, expr);
+            field.kind = newProp;
+          }
+        }
+      }
+    }
+
+    return fields;
+  }
+}

--- a/sample/src/tests/TestReadOnly.hx
+++ b/sample/src/tests/TestReadOnly.hx
@@ -1,0 +1,25 @@
+package tests;
+
+import porcelain.ReadOnly;
+import tracker.Observable;
+
+class ReadOnlyObservers implements Observable implements ReadOnly {
+  @observe public var myString: String = 'string';
+  @observe public var myInt: Int = 1;
+
+  public var myPublicString: String;
+
+  public function new() {}
+}
+
+class TestReadOnly {
+  var observers: ReadOnlyObservers;
+
+  public function new() {
+    observers = new ReadOnlyObservers();
+
+    // Uncomment the following and the property should not be writable
+    // observers.myString = 'a new string';
+    // observers.myInt = 1;
+  }
+}


### PR DESCRIPTION
Adds the ReadOnly macro and interface created for FableMaker Editor's AppState/Store pattern.